### PR TITLE
docs: Fixed a few typos and grammatical errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,5 +29,5 @@ Here are some examples:
 - Most PRs should include a description of what is changing to the
   [CHANGELOG.md](CHANGELOG.md) file. Use your own judgement on what warrants
   inclusion, the expectation is that 95% of PRs will include an edit to the
-  change log. Maintainers will let you know if you if you include and its not
+  change log. Maintainers will let you know if you need to include it or its not
   needed.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Making you're next machine learning project a breeze to write!
 
 - Features
   - The [new feature tutorial](docs/tutorial/FEATURE.md) will walk you through
-    how to write a new DFFML feature to gernerate data for a dataset.
+    how to write a new DFFML feature to generate data for a dataset.
 - Models
   - The [new model tutorial](docs/tutorial/MODEL.md) will walk you through how
     to wrap your favorite framework or a custom implementation in the DFFML

--- a/docs/FEATURE.md
+++ b/docs/FEATURE.md
@@ -50,4 +50,4 @@ entry_points={
 ## Tutorial
 
 The [new feature tutorial](tutorial/FEATURE.md) will walk you through how to
-write a new DFFML feature to gernerate data for a dataset.
+write a new DFFML feature to generate data for a dataset.

--- a/docs/tutorial/FEATURE.md
+++ b/docs/tutorial/FEATURE.md
@@ -3,7 +3,7 @@
 ## Create the Package
 
 To create a new feature we first create a new python package. DFFML has a script
-to created it for you.
+to create it for you.
 
 We're going to create a feature that multiplies float values by `4.2`.
 
@@ -134,7 +134,7 @@ from dffml_feature_string.feature.string_by_4_point_2 import \
 ### Modify `evaluates` test
 
 The tests start out with one testcase which should work. Modify that so that it
-still works. If you don't it should fail because the string being parsed can't
+still works. If you don't, it should fail because the string being parsed can't
 be parsed into a float.
 
 ```python


### PR DESCRIPTION
While going through the docs to start contributing to the project, I found a few typos and grammatical errors. Fixed them in this PR.