### PR TITLE
skel: source: entry_points correction

### DIFF
--- a/dffml/skel/source/setup.py
+++ b/dffml/skel/source/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from dffml_setup_common import SETUP_KWARGS, IMPORT_NAME
 
 SETUP_KWARGS["entry_points"] = {
-    "dffml.service.cli": [f"misc = {IMPORT_NAME}.misc:Misc"]
+    "dffml.source": [f"misc = {IMPORT_NAME}.misc:Misc"]
 }
 
 setup(**SETUP_KWARGS)


### PR DESCRIPTION
* setup() kwargs entry_points was the service entrypoint,
  corrected to the source entrypoint.

Fixes: #162