### PR TITLE
bug : run.sh : WhiteSpace Checker Solved.

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -74,8 +74,13 @@ function run_whitespace() {
     rm -f "$whitespace"
   }
   trap rmtempfile EXIT
-  ( find dffml -type f -name \*.py -exec grep -EHn " +$" {} \; ) 2>&1 \
-    | tee "$whitespace"
+  for file in `find $1 -type f -name "*.py"`;
+  do
+        nlines=`tail -n 1 $file | grep '^$' | wc -l`
+        if [ $nlines -eq 1 ]
+                then echo $file | tee "$whitespace"
+        fi
+  done;
   lines=$(wc -l < "$whitespace")
   if [ "$lines" -ne 0 ]; then
     echo "Trailing whitespace found" >&2


### PR DESCRIPTION
This PR closes issue #232 

``ci/run.sh`` whitespace checking function was not working fine, so added some changes to it which now work fine, it exits non-zero value if trailing whitespace is found.

I have added whitespaces to two file ``base.py`` and ``cli.py`` .
After running script it shows filename with trailing whitespaces and exit with non-zero value.

![image](https://user-images.githubusercontent.com/30001594/67985169-419d7e80-fc4e-11e9-88c2-d405f52b6aef.png)

I am using Ubuntu 16.04 LTS.
