### PR TITLE
util: cli: Default to FastChildWatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The model predict operation will now raise an exception if the model it is
   passed via it's config is a class rather than an instance.
 - `entry_point` and friends have been renamed to `entrypoint`.
+- Use `FastChildWatcher` when run via the CLI to prevent `BlockingIOError`s.
 ### Fixed
 - CONTRIBUTING.md has `-e` in the wrong place in the getting setup section.
 - Since moving to auto `args()` and `config()`, BaseConfigurable no longer

--- a/dffml/util/cli/cmd.py
+++ b/dffml/util/cli/cmd.py
@@ -198,6 +198,15 @@ class CMD(object):
         """
         if loop is None:
             loop = asyncio.get_event_loop()
+            # In Python 3.8 ThreadedChildWatcher becomes the default which
+            # should work fine for us. However, in Python 3.7 SafeChildWatcher
+            # is the default and may cause BlockingIOErrors when many
+            # subprocesses are created
+            # https://docs.python.org/3/library/asyncio-policy.html#asyncio.FastChildWatcher
+            if sys.version_info.major == 3 and sys.version_info.minor == 7:
+                watcher = asyncio.FastChildWatcher()
+                asyncio.set_child_watcher(watcher)
+                watcher.attach_loop(loop)
         result = None
         try:
             result = loop.run_until_complete(cls._main(*argv[1:]))


### PR DESCRIPTION
In Python 3.7 we may run into issues when spawning many subprocesses.
Use the FastChildWatcher on the CLI event loop to avoid BlockingIOErrors
which may come from this. In Python 3.8 the default watcher is the
ThreadedChildWatcher which should work fine to avoid the
BlockingIOErrors.

See https://bugs.python.org/issue32776 for more info.

Signed-off-by: John Andersen <johnandersenpdx@gmail.com>