### PR TITLE
feature: Convert tests to doctests and add example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to run a subflow as if it were an operation using the
   `dffml.dataflow.run` operation.
 - Support for operations without inputs.
+- Partial doctestable examples to `features.py`
 ### Fixed
 - New model tutorial mentions file paths that should be edited.
 - DataFlow is no longer a dataclass to prevent it from being exported

--- a/dffml/feature/feature.py
+++ b/dffml/feature/feature.py
@@ -113,6 +113,27 @@ class Feature(abc.ABC, Entrypoint):
     Once the appropriate data is fetched the parse method is responsible for
     storing the parts of that data which will be used to calculate in the
     subclass
+
+    Examples
+    --------
+
+    Define a feature using load_def:
+    >>> feature = Feature.load_def("example", "float", 10)
+    >>> feature.dtype()
+    float
+    >>> feature.NAME
+    "example"
+    >>> feature.length()
+    10
+
+    Defining a feature directly using DefFeature:
+    >>> feature = DefFeature("example2", "int", 20)
+    >>> feature.dtype()
+    int
+    >>> feature.NAME
+    "example2"
+    >>> feature.length()
+    20
     """
 
     LOGGER = LOGGER.getChild("Feature")
@@ -147,6 +168,13 @@ class Feature(abc.ABC, Entrypoint):
     def dtype(self) -> Type:
         """
         Models need to know a Feature's datatype.
+
+        Examples
+        --------
+
+        >>> feature = Feature()
+        >>> feature.dtype()
+        int
         """
         self.LOGGER.warning("%s dtype unimplemented", self)
         return int
@@ -155,6 +183,13 @@ class Feature(abc.ABC, Entrypoint):
         """
         Models need to know a Feature's length, 1 means single value, more than
         that is the length of the array calc returns.
+
+        Examples
+        --------
+
+        >>> feature = Feature()
+        >>> feature.length()
+        1
         """
         self.LOGGER.warning("%s length unimplemented", self)
         return 1


### PR DESCRIPTION
Hello, 
I am probably little late here but I converted some tests in test_features.py to doctest examples in feature.py.
I wanted to confirm whether it is the desired result of the Doctest-able Examples GSOC project?