### PR TITLE
docs: hiding of python prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Python prompts `>>>` can now be enabled or disabled for easy copying of code into interactive sessions.
 ### Changed
 - Renamed `"arg"` to `"plugin"`.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,9 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+def setup(app):
+    app.add_javascript("copybutton.js")
+
 # -- Extension configuration -------------------------------------------------
 
 napoleon_numpy_docstring = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,8 +87,10 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+
 def setup(app):
     app.add_javascript("copybutton.js")
+
 
 # -- Extension configuration -------------------------------------------------
 

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -11,5 +11,8 @@ python3.7 scripts/docs.py
 python3.7 -c 'import os, pkg_resources; [e.load() for e in pkg_resources.iter_entry_points("console_scripts") if e.name.startswith("sphinx-build")][0]()' -b html docs pages \
   || (echo "[ERROR] Failed run sphinx, is it installed (pip install -U .[dev])?" 1>&2 ; exit 1)
 cp -r docs/images pages/
-wget -P pages/_static "https://raw.githubusercontent.com/python/python-docs-theme/master/python_docs_theme/static/copybutton.js"
+curl -sSL -o pages/_static/copybutton.js "https://raw.githubusercontent.com/python/python-docs-theme/master/python_docs_theme/static/copybutton.js"
+sha384sum -c - <<EOF
+bf80c778867bd87d14588ff72ae10632b331427379a299ab2ac4d7ddefa9b648313720b796ab441359e0e47daf738109 pages/_static/copybutton.js
+EOF
 touch pages/.nojekyll

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -11,4 +11,5 @@ python3.7 scripts/docs.py
 python3.7 -c 'import os, pkg_resources; [e.load() for e in pkg_resources.iter_entry_points("console_scripts") if e.name.startswith("sphinx-build")][0]()' -b html docs pages \
   || (echo "[ERROR] Failed run sphinx, is it installed (pip install -U .[dev])?" 1>&2 ; exit 1)
 cp -r docs/images pages/
+wget -P pages/_static "https://raw.githubusercontent.com/python/python-docs-theme/master/python_docs_theme/static/copybutton.js"
 touch pages/.nojekyll


### PR DESCRIPTION
The python prompt `>>>` can be enabled or disabled. this way users can easily copy paste code in interactive sessions.
closes #438 