### PR TITLE
Minute name change in cargo_audit.py file

### DIFF
--- a/examples/shouldi/shouldi/cargo_audit.py
+++ b/examples/shouldi/shouldi/cargo_audit.py
@@ -7,7 +7,7 @@ from dffml.df.types import Definition
 
 package_src_dir = Definition(name="package_src_dir", primitive="str")
 cargo_audit_output = Definition(
-    name="golangci_lint_output", primitive="Dict[str, Any]"
+    name="cargo_audit_output", primitive="Dict[str, Any]"
 )
 
 


### PR DESCRIPTION
Must have forgotten to rename the name of the `Definition`.