### PR TITLE
gitpod: Fix automated dev setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,10 @@
 image:
     file: scripts/gitpod.Dockerfile
 tasks:
-  - init: pip install -U pip && pip install -e .[dev] && dffml service dev install && echo -e '#!/bin/sh\nexec python3.7 -m black --check .' > .git/hooks/pre-commit && chmod 755 .git/hooks/pre-commit
+  - init: >
+      pip install -U pip &&
+      pip install -e .[dev] &&
+      rm $(pyenv prefix)/lib/libpython* &&
+      dffml service dev install &&
+      echo -e '#!/bin/sh\nexec python3 -m black --check .' > .git/hooks/pre-commit &&
+      chmod 755 .git/hooks/pre-commit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Data Flow Facilitator for Machine Learning (dffml)
 
 [![Actions Status](https://github.com/intel/dffml/workflows/Tests/badge.svg?branch=master&event=push)](https://github.com/intel/dffml/actions)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/intel/dffml)
 [![codecov](https://codecov.io/gh/intel/dffml/branch/master/graph/badge.svg)](https://codecov.io/gh/intel/dffml)
 [![CII](https://bestpractices.coreinfrastructure.org/projects/2594/badge)](https://bestpractices.coreinfrastructure.org/projects/2594)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.svg)](https://gitter.im/dffml/community)

--- a/scripts/gitpod.Dockerfile
+++ b/scripts/gitpod.Dockerfile
@@ -7,7 +7,7 @@ RUN echo 'unset PIP_USER' >> ~/.bashrc
 USER root
 
 RUN apt-get -q update && \
-  apt-get install -yq tmux git && \
+  apt-get install -yq tmux libboost-all-dev && \
   rm -rf /var/lib/apt/lists/* && \
   pyenv global $(pyenv global | grep 3\\.) && \
   curl -sSL "https://github.com/XAMPPRocky/tokei/releases/download/v10.1.1/tokei-v10.1.1-x86_64-unknown-linux-gnu.tar.gz" \


### PR DESCRIPTION
Hi there! 👋 I work on [gitpod.io](https://www.gitpod.io), and noticed this project has an automated dev setup based on Gitpod, so I couldn't help it and had to give `dffml` a try.

I stumbled on a few issues along the way, which I've fixed in this Pull Request.

- At first, the automated setup failed with:

```
Could NOT find Boost (missing: Boost_INCLUDE_DIR program_options system
thread unit_test_framework)
```

This was resolved by installing `libboost-all-dev` in the Dockerfile. (Also, note that `git` is already installed in `gitpod/workspace-full`, so I've removed it from the Dockerfile.)

- The next error was:

```
    Scanning dependencies of target pylibvw
    [ 98%] Building CXX object python/CMakeFiles/pylibvw.dir/pylibvw.cc.o
    [100%] Linking CXX shared library ../../lib.linux-x86_64-3.8/pylibvw.so
    /usr/bin/ld: /home/gitpod/.pyenv/versions/3.8.2/lib/libpython3.8.a(floatobject.o): relocation R_X86_64_PC32 against symbol `PyFloat_Type' can not be used when making a shared object; recompile with -fPIC
    /usr/bin/ld: final link failed: bad value
```

This one was a bit trickier, but after researching it a bit, I found https://github.com/mkleehammer/pyodbc/issues/573#issuecomment-626897172 which suggests renaming the faulty library. So I've simply removed it with `rm $(pyenv prefix)/lib/libpython*`, which successfully worked around the problem.

Finally, I've made a few other small improvements to the setup:
- Made `.gitpod.yml` init task multi-line for better readability
- Fixed pre-commit hook (`python3.7` --> `python3`)
- Added ready-to-code Readme badge

It now initializes successfully:

![Screenshot 2020-05-22 at 09 25 47](https://user-images.githubusercontent.com/599268/82643272-84856a80-9c0f-11ea-9d92-25e4ae673fb1.png)

I'm now able to use the `dffml` CLI tool in Gitpod, although I'm not sure what to do with it yet. On a side note, maybe the `.gitpod.yml` could have a `command` task that automatically starts a `dffml` example when the workspace opens, so that people who open `dffml` in Gitpod can immediately get a good idea of what it does & how to use it.