### PR TITLE
examples: DataFlow: Examples which use locked definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make every model's directory property required
 - New model AutoClassifierModel based on `AutoSklearn`.
 - New model AutoSklearnRegressorModel based on `AutoSklearn`.
+- Example showing usage of locks in dataflow.
 ### Changed
 - Update record `__str__` method to output in tabular format
 - Update NER Model to use transformers 2.11.0

--- a/docs/tutorials/dataflows/index.rst
+++ b/docs/tutorials/dataflows/index.rst
@@ -8,3 +8,4 @@ Here we have some examples to better understand the DFFML DataFlows.
     :caption: Contents:
 
     io
+    locking

--- a/docs/tutorials/dataflows/locking.rst
+++ b/docs/tutorials/dataflows/locking.rst
@@ -1,0 +1,66 @@
+Using Locks In DataFlow
+=======================
+
+All the operations in DFFML runs asynchrously. DFFML takes care of locking objects which
+might be used by multiple operations so that you don't run in to any race conditions.
+This example shows one such usage.
+
+.. note::
+
+    All the code for this example is located under the
+    `examples/dataflow/locking <https://github.com/intel/dffml/blob/master/examples/dataflow/locking>`_
+    directory of the DFFML source code.
+
+**example.py**
+
+.. literalinclude:: /../examples/dataflow/locking/example.py
+    :linenos:
+    :lineno-start: 1
+    :lines: 1-9
+
+First we define all the Definitions. Note that ``LOCKED_OBJ`` has ``lock=True``.
+
+.. literalinclude:: /../examples/dataflow/locking/example.py
+    :linenos:
+    :lineno-start: 10
+    :lines: 10-22
+
+Our operation ``run_me`` takes an object(of defintion OBJ) sets the ``i`` aattribute of it, sleeps for given
+time finally prints the value which was given as input and the current value of the object.
+We'll run the dataflow with two values for i. If the operations run as expected when printing,
+the value given as input and that of the object would be same.
+
+.. literalinclude:: /../examples/dataflow/locking/example.py
+    :linenos:
+    :lineno-start: 25
+    :lines: 25-40
+
+But this codeblock gives an output
+
+.. code-block:: json
+
+    Running dataflow without locked object
+    set i = 2, got i = 1
+    set i = 1, got i = 1
+    set i = 2, got i = 1
+    set i = 1, got i = 1
+
+We can see that the output is not what we expect. Since everything is running asynchrously,
+when one operations sleeps the other operation might start running and it replaces the 
+value. This is where locks come handy. We'll set ``run_me`` to take object of definition
+``LOCKED_OBJ`` instead of ``OBJ`` and run the dataflow again.
+
+.. literalinclude:: /../examples/dataflow/locking/example.py
+    :linenos:
+    :lineno-start: 42
+    :lines: 42-63
+
+This time the output is as expected
+
+.. code-block:: json
+
+    Running dataflow with locked object
+    set i = 2, got i = 2
+    set i = 1, got i = 1
+    set i = 2, got i = 2
+    set i = 1, got i = 1

--- a/examples/dataflow/locking/example.py
+++ b/examples/dataflow/locking/example.py
@@ -1,0 +1,65 @@
+import asyncio
+from dffml import Definition, DataFlow, Input, op, run
+
+OBJ = Definition(name="obj", primitive="Any")
+LOCKED_OBJ = Definition(name="locked_obj", primitive="Any", lock=True)
+SLEEP_TIME = Definition(name="sleep_time", primitive="int")
+INTEGER = Definition(name="intefer", primitive="int")
+
+TEST_OUT = []
+
+
+class TestObj:
+    def __init__(self):
+        self.i = -1
+
+
+@op(inputs={"obj": OBJ, "sleep_for": SLEEP_TIME, "i": INTEGER})
+async def run_me(obj, sleep_for, i) -> None:
+    obj.i = i
+    await asyncio.sleep(sleep_for)
+    s = f"set i = {i}, got i = {obj.i}"
+    print(s)
+    TEST_OUT.append([i, obj.i])
+
+
+async def main():
+    dataflow = DataFlow(
+        operations={"run1": run_me.op, "run2": run_me.op},
+        implementations={run_me.op.name: run_me.imp},
+    )
+
+    print("Running dataflow without locked object")
+    obj = TestObj()
+    dataflow.seed = [
+        Input(value=obj, definition=OBJ),
+        Input(value=0.2, definition=SLEEP_TIME),
+        Input(value=2, definition=INTEGER),
+        Input(value=1, definition=INTEGER),
+    ]
+    async for ctx, result in run(dataflow):
+        pass
+
+    print("Running dataflow with locked object")
+    run_me.op = run_me.op._replace(
+        inputs={"obj": LOCKED_OBJ, "sleep_for": SLEEP_TIME, "i": INTEGER}
+    )
+    dataflow = DataFlow(
+        operations={"run1": run_me.op, "run2": run_me.op},
+        implementations={run_me.op.name: run_me.imp},
+    )
+    obj = TestObj()
+    dataflow.seed = [
+        Input(value=obj, definition=LOCKED_OBJ),
+        Input(value=0.2, definition=SLEEP_TIME),
+        Input(value=2, definition=INTEGER),
+        Input(value=1, definition=INTEGER),
+    ]
+    async for ctx, result in run(dataflow):
+        pass
+
+    for x in TEST_OUT[4:]:
+        assert x[0] == x[1]
+
+
+asyncio.run(main())


### PR DESCRIPTION
Add examples demonstrating locking of objects.

```
async def run_me(obj, sleep_for, i) -> None:
    obj.i = i
    await asyncio.sleep(sleep_for)
    print(f"set i = {i}, got i = {obj.i}")
```

Running `run_me` without a locked obj would give unexpected results, for example
```
set i = 2, got i = 1
set i = 1, got i = 1
set i = 2, got i = 1
set i = 1, got i = 1
```

with locking
```
set i = 2, got i = 2
set i = 1, got i = 1
set i = 2, got i = 2
set i = 1, got i = 1

```