### PR TITLE
df: input flow: Add get_alternate_definitions helper function

### DIFF
--- a/dffml/df/memory.py
+++ b/dffml/df/memory.py
@@ -490,12 +490,10 @@ class MemoryInputNetworkContext(BaseInputNetworkContext):
                     # Ensure all conditions from all origins are True
                     for origin in origins:
                         # See comment in input_flow.inputs section
-                        alternate_definitions = []
-                        if isinstance(origin, tuple) and isinstance(
-                            origin[1], (list, tuple)
-                        ):
-                            alternate_definitions = origin[1]
-                            origin = origin[0]
+                        (
+                            alternate_definitions,
+                            origin,
+                        ) = input_flow.get_alternate_definitions(origin)
                         # Bail if the condition doesn't exist
                         if not origin in by_origin:
                             return
@@ -547,12 +545,10 @@ class MemoryInputNetworkContext(BaseInputNetworkContext):
                             # These definitions will be used instead of the
                             # default one the input specified for the
                             # operation).
-                            alternate_definitions = []
-                            if isinstance(origin, tuple) and isinstance(
-                                origin[1], (list, tuple)
-                            ):
-                                alternate_definitions = origin[1]
-                                origin = origin[0]
+                            (
+                                alternate_definitions,
+                                origin,
+                            ) = input_flow.get_alternate_definitions(origin)
                             # Don't try to grab inputs from an origin that
                             # doesn't have any to give us
                             if not origin in by_origin:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             "sphinx",
             "sphinx_rtd_theme",
             "recommonmark",
-            "black",
+            "black==19.10b0",
             "jsbeautifier",
             "twine",
         ],


### PR DESCRIPTION
We had a lack of clarity around what was going on with alternate
definitions in commit 2ed6e172669f9f9c15c96409ea5ed5673c5b6c8b. There
were several if statements where we are looping through the origins
and if the origin is a dict, we check if the value is a tuple or a list.

If it is not, the key is the operation instance name and the value is
the output name for that operation instance.

If it is, the key is the origin and the value is the list or tuple of
definition names which are acceptable alternate definitions when the
input is coming from that origin.

This patch adds a helper method to make that more clear.

Signed-off-by: John Andersen <johnandersenpdx@gmail.com>