### PR TITLE
WIP: setup: notify incompatible Python at installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,20 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2019 Intel Corporation
 import os
+import sys
 import ast
 import pathlib
 from io import open
 import importlib.util
 from setuptools import find_packages, setup
+
+
+class InstallException(Exception):
+    pass
+
+
+if sys.version_info.major != 3 and sys.version_info.minor < 7:
+    raise InstallException("dffml is incompatible with Python version < 3.7!")
 
 with open(pathlib.Path("dffml", "version.py"), "r") as f:
     for line in f:


### PR DESCRIPTION
These changes checks Python version at installation and throws exception if current Python version is less than 3.7. This is because we are using Python 3.7 features which are not available at older versions (e.g. `AsyncExitStack` in `dffml/util/asynchelper.py`).

![example in Colab](https://i.imgur.com/O4K7YMe.png)