### PR TITLE
ci: Run base package tests on Windows

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -158,3 +158,41 @@ jobs:
         if [ "x${PLUGIN}" = "x." ]; then
           CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} codecov
         fi
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout full upstream repo
+      run: |
+        git remote set-url origin https://github.com/intel/dffml
+        git fetch --prune --unshallow
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Get pip cache
+      id: pip-cache
+      run: |
+        python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
+    - name: pip cache
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Setup DFFML
+      run: |
+        pip install -U pip setuptools wheel
+        pip install -e .[dev]
+        pip install torch===1.7.0 torchvision===0.8.1 -f https://download.pytorch.org/whl/torch_stable.html
+        dffml service dev install -skip model/vowpalWabbit model/autosklearn model/daal4py
+        # Remove dataclasses. See https://github.com/intel/dffml/issues/882
+        python scripts/tempfix/pytorch/pytorch/46930.py
+    - name: Test
+      run: python setup.py test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
         git fetch --prune --unshallow
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Use Node.js ${{ matrix.node-version }}
@@ -86,7 +86,7 @@ jobs:
         git fetch --prune --unshallow
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get pip cache
@@ -172,7 +172,7 @@ jobs:
         git remote set-url origin https://github.com/intel/dffml
         git fetch --prune --unshallow
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get pip cache

--- a/dffml/util/cli/cmd.py
+++ b/dffml/util/cli/cmd.py
@@ -262,7 +262,11 @@ class CMD(object):
             # In order to use asyncio.subprocess_create_exec from event loops in
             # non-main threads we have to call asyncio.get_child_watcher(). This
             # is only for Python 3.7
-            if sys.version_info.major == 3 and sys.version_info.minor == 7:
+            if (
+                sys.version_info.major == 3
+                and sys.version_info.minor == 7
+                and sys.platform != "win32"
+            ):
                 asyncio.get_child_watcher()
             # Create a new event loop
             loop = asyncio.get_event_loop()

--- a/dffml/util/net.py
+++ b/dffml/util/net.py
@@ -184,16 +184,16 @@ def cached_download_unpack_archive(
     >>> from dffml import cached_download_unpack_archive
     >>>
     >>> @cached_download_unpack_archive(
-    ...     "https://github.com/intel/dffml/archive/152c2b92535fac6beec419236f8639b0d75d707d.tar.gz",
+    ...     "https://github.com/intel/dffml/archive/c4469abfe6007a50144858d485537324046ff229.tar.gz",
     ...     "dffml.tar.gz",
     ...     "dffml",
-    ...     "32ba082cd8056ff4ddcb68691a590c3cb8fea2ff75c0265b8d844c5edc7eaef54136160c6090750e562059b957355b15",
+    ...     "bb9bb47c4e6e4c6b7147bb3c000bc4069d69c0c77a3e560b69f476a78e6b5084adf5467ee83cbbcc47ba5a4a0696fdfc",
     ... )
-    ... async def files_in_dffml_commit_152c2b(dffml_dir):
+    ... async def files_in_dffml_commit_c4469a(dffml_dir):
     ...     return len(list(dffml_dir.rglob("**/*")))
     >>>
-    >>> asyncio.run(files_in_dffml_commit_152c2b())
-    594
+    >>> asyncio.run(files_in_dffml_commit_c4469a())
+    124
     """
     directory_path = pathlib.Path(directory_path)
 

--- a/tests/docs/test_consoletest.py
+++ b/tests/docs/test_consoletest.py
@@ -246,7 +246,7 @@ def mktestcase(filepath: pathlib.Path, relative: pathlib.Path):
 
 
 for filepath in DOCS_PATH.rglob("*.rst"):
-    if ":test:" not in pathlib.Path(filepath).read_text():
+    if b":test:" not in pathlib.Path(filepath).read_bytes():
         continue
     relative = filepath.relative_to(DOCS_PATH).with_suffix("")
     name = "test_" + str(relative).replace(os.sep, "_")

--- a/tests/util/test_net.py
+++ b/tests/util/test_net.py
@@ -4,6 +4,7 @@ import sys
 import shutil
 import tarfile
 import pathlib
+import platform
 import tempfile
 import contextlib
 import unittest.mock
@@ -49,6 +50,7 @@ if sys.version_info.major == 3 and sys.version_info.minor >= 8:
     ARCHIVE_HASH = "28f82a69e04fa2dfb6e09c94082d6c6100c546e23d2331c78f307601ccc0265374c3c8abedff60ad0caccb6e8fc3995a"
 
 
+@unittest.skipIf(platform.system() == "Windows", "Does not work on Windows")
 class TestNet(AsyncTestCase):
     def verify_extracted_contents(self, extracted):
         self.assertTrue((extracted / "somedir").is_dir())


### PR DESCRIPTION
3 tests are failing on CI, out of which 2 are the same as what I have locally, one is different (One exists on my system, not on CI, and one on CI and not locally). Logs:

Local:
```console
======================================================================
ERROR: test_run_commands (tests.docs.test_consoletest.TestFunctions)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\yashl\main\projects\dffml\dffml\util\asynctestcase.py", line 69, in run_it
    result = self.loop.run_until_complete(coro(*args, **kwargs))
  File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\asyncio\base_events.py", line 616, in run_until_compl
ete
    return future.result()
  File "c:\users\yashl\main\projects\dffml\tests\docs\test_consoletest.py", line 106, in test_run_commands
    await consoletest.run_commands(
  File "c:\users\yashl\main\projects\dffml\tests\docs\..\..\docs\_ext\consoletest.py", line 425, in run_commands
    proc = subprocess.Popen(
  File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\subprocess.py", line 1307, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
FileNotFoundError: [WinError 2] The system cannot find the file specified

======================================================================
ERROR: test_records (tests.source.test_op.TestOpSource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\yashl\main\projects\dffml\dffml\util\asynctestcase.py", line 69, in run_it
    result = self.loop.run_until_complete(coro(*args, **kwargs))
  File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\asyncio\base_events.py", line 616, in run_until_compl
ete
    return future.result()
  File "c:\users\yashl\main\projects\dffml\tests\source\test_op.py", line 91, in test_records
    self.assertEqual(len(parser(fileobj.name)), 1)
  File "c:\users\yashl\main\projects\dffml\tests\source\test_op.py", line 43, in parser
    with open(json_file) as f:
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\yashl\\AppData\\Local\\Temp\\tmpcgpouksy'

======================================================================
ERROR: test_docstring (tests.test_docstrings.util_net_cached_download_unpack_archive)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\yashl\main\projects\dffml\tests\test_docstrings.py", line 209, in testcase
    run_doctest(obj, state)
  File "c:\users\yashl\main\projects\dffml\tests\test_docstrings.py", line 178, in run_doctest
    raise Exception(output.getvalue())
Exception: **********************************************************************
File "c:\users\yashl\main\projects\dffml\dffml\util\net.py", line 195, in cached_download_unpack_archive
Failed example:
    asyncio.run(files_in_dffml_commit_152c2b())
Exception raised:
    Traceback (most recent call last):
      File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\doctest.py", line 1336, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest cached_download_unpack_archive[3]>", line 1, in <module>
        asyncio.run(files_in_dffml_commit_152c2b())
      File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\asyncio\runners.py", line 43, in run
        return loop.run_until_complete(main)
      File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\asyncio\base_events.py", line 616, in run_until_c
omplete
        return future.result()
      File "c:\users\yashl\main\projects\dffml\dffml\util\net.py", line 215, in wrapper
        return await func(*(list(args) + [directory_path]), **kwds)
      File "<doctest cached_download_unpack_archive[2]>", line 8, in files_in_dffml_commit_152c2b
        return len(list(dffml_dir.rglob("**/*")))
      File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\pathlib.py", line 1148, in rglob
        for p in selector.select_from(self):
      File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\pathlib.py", line 583, in _select_from
        for p in successor_select(starting_point, is_dir, exists, scandir):
      File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\pathlib.py", line 582, in _select_from
        for starting_point in self._iterate_directories(parent_path, is_dir, scandir):
      File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\pathlib.py", line 572, in _iterate_directories
        for p in self._iterate_directories(path, is_dir, scandir):
      File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\pathlib.py", line 572, in _iterate_directories
        for p in self._iterate_directories(path, is_dir, scandir):
      File "C:\Users\yashl\AppData\Local\Programs\Python\Python38\lib\pathlib.py", line 566, in _iterate_directories
        entry_is_dir = entry.is_dir()
    OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'dffml\\dffml-152c2b9253
5fac6beec419236f8639b0d75d707d\\docs\\changelog.md'


----------------------------------------------------------------------
Ran 288 tests in 53.567s

FAILED (errors=3, skipped=24)
```

CI:
```console
======================================================================
ERROR: test_records (tests.source.test_op.TestOpSource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "d:\a\dffml\dffml\dffml\util\asynctestcase.py", line 69, in run_it
    result = self.loop.run_until_complete(coro(*args, **kwargs))
  File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\asyncio\base_events.py", line 616, in run_until_complete
    return future.result()
  File "d:\a\dffml\dffml\tests\source\test_op.py", line 91, in test_records
    self.assertEqual(len(parser(fileobj.name)), 1)
  File "d:\a\dffml\dffml\tests\source\test_op.py", line 43, in parser
    with open(json_file) as f:
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmp43gpinmb'

======================================================================
ERROR: test_docstring (tests.test_docstrings.util_net_cached_download_unpack_archive)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "d:\a\dffml\dffml\tests\test_docstrings.py", line 209, in testcase
    run_doctest(obj, state)
  File "d:\a\dffml\dffml\tests\test_docstrings.py", line 178, in run_doctest
    raise Exception(output.getvalue())
Exception: **********************************************************************
File "d:\a\dffml\dffml\dffml\util\net.py", line 195, in cached_download_unpack_archive
Failed example:
    asyncio.run(files_in_dffml_commit_152c2b())
Exception raised:
    Traceback (most recent call last):
      File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\doctest.py", line 1336, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest cached_download_unpack_archive[3]>", line 1, in <module>
        asyncio.run(files_in_dffml_commit_152c2b())
      File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\asyncio\runners.py", line 44, in run
        return loop.run_until_complete(main)
      File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\asyncio\base_events.py", line 616, in run_until_complete
        return future.result()
      File "d:\a\dffml\dffml\dffml\util\net.py", line 215, in wrapper
        return await func(*(list(args) + [directory_path]), **kwds)
      File "<doctest cached_download_unpack_archive[2]>", line 8, in files_in_dffml_commit_152c2b
        return len(list(dffml_dir.rglob("**/*")))
      File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\pathlib.py", line 1151, in rglob
        for p in selector.select_from(self):
      File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\pathlib.py", line 586, in _select_from
        for p in successor_select(starting_point, is_dir, exists, scandir):
      File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\pathlib.py", line 585, in _select_from
        for starting_point in self._iterate_directories(parent_path, is_dir, scandir):
      File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\pathlib.py", line 575, in _iterate_directories
        for p in self._iterate_directories(path, is_dir, scandir):
      File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\pathlib.py", line 575, in _iterate_directories
        for p in self._iterate_directories(path, is_dir, scandir):
      File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\pathlib.py", line 569, in _iterate_directories
        entry_is_dir = entry.is_dir()
    OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'dffml\\dffml-152c2b92535fac6beec419236f8639b0d75d707d\\docs\\changelog.md'


======================================================================
ERROR: test_run (tests.tutorials.dataflows.test_locking.TestLocking)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "d:\a\dffml\dffml\tests\tutorials\dataflows\test_locking.py", line 13, in test_run
    stdout = subprocess.check_output([sys.executable, str(EXAMPLE_PATH)])
  File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['C:\\hostedtoolcache\\windows\\Python\\3.8.6\\x64\\python.exe', 'd:\\a\\dffml\\dffml\\examples\\dataflow\\locking\\example.py']' returned non-zero exit status 1.

----------------------------------------------------------------------
Ran 288 tests in 25.380s

FAILED (errors=3, skipped=9)
```

Currently skipped only the TestNet tests on Windows, since they aren't yet expected to work.