### PR TITLE
dffml: plugins: Added OS check for autosklearn

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -193,7 +193,7 @@ jobs:
         pip install -U pip setuptools wheel
         pip install -e .[dev]
         pip install torch===1.7.0 torchvision===0.8.1 -f https://download.pytorch.org/whl/torch_stable.html
-        dffml service dev install -skip model/vowpalWabbit model/autosklearn model/daal4py
+        dffml service dev install -skip model/vowpalWabbit model/daal4py
         # Remove dataclasses. See https://github.com/intel/dffml/issues/882
         python scripts/tempfix/pytorch/pytorch/46930.py
     - name: Test
@@ -230,7 +230,7 @@ jobs:
       run: |
         pip install -U pip setuptools wheel
         pip install -e .[dev]
-        dffml service dev install -skip model/vowpalWabbit model/autosklearn model/daal4py
+        dffml service dev install -skip model/vowpalWabbit model/daal4py
         # Remove dataclasses. See https://github.com/intel/dffml/issues/882
         python scripts/tempfix/pytorch/pytorch/46930.py
     - name: Test

--- a/dffml/plugins.py
+++ b/dffml/plugins.py
@@ -116,7 +116,7 @@ CORE_PLUGIN_DEPS = {
         "cython": lambda: inpath("cython"),
     }
     if platform.system() not in {"Windows", "Darwin"}
-    and not python_package_installed("auto_sklearn")
+    and not python_package_installed("autosklearn")
     else {},
 }
 

--- a/dffml/plugins.py
+++ b/dffml/plugins.py
@@ -45,7 +45,7 @@ if sys.version_info.major == 3 and sys.version_info.minor < 8:
         ("model", "daal4py"),
     ]
 
-if platform.system() in {"Windows", "Darwin"}:
+if platform.system() not in {"Windows", "Darwin"}:
     CORE_PLUGINS += [
         ("model", "autosklearn"),
     ]

--- a/dffml/plugins.py
+++ b/dffml/plugins.py
@@ -115,7 +115,8 @@ CORE_PLUGIN_DEPS = {
         "swig": lambda: inpath("swig"),
         "cython": lambda: inpath("cython"),
     }
-    if not python_package_installed("auto_sklearn")
+    if platform.system() not in {"Windows", "Darwin"}
+    and not python_package_installed("auto_sklearn")
     else {},
 }
 

--- a/dffml/plugins.py
+++ b/dffml/plugins.py
@@ -6,6 +6,7 @@ import os
 import sys
 import pathlib
 import inspect
+import platform
 import tempfile
 import contextlib
 import subprocess
@@ -33,7 +34,6 @@ CORE_PLUGINS = [
     ("model", "tensorflow_hub"),
     ("model", "transformers"),
     ("model", "vowpalWabbit"),
-    ("model", "autosklearn"),
     ("model", "xgboost"),
     ("model", "pytorch"),
     ("model", "spacy"),
@@ -43,6 +43,11 @@ CORE_PLUGINS = [
 if sys.version_info.major == 3 and sys.version_info.minor < 8:
     CORE_PLUGINS += [
         ("model", "daal4py"),
+    ]
+
+if platform.system() in {"Windows", "Darwin"}:
+    CORE_PLUGINS += [
+        ("model", "autosklearn"),
     ]
 
 CORE_PLUGINS += [


### PR DESCRIPTION
Added an OS check to exclude/include autosklearn into the core plugins. Fixes[ #887](https://github.com/intel/dffml/issues/887).