### PR TITLE
model: pytorch: Custom exception when loss function is misspelled

### DIFF
--- a/model/pytorch/dffml_model_pytorch/pytorch_base.py
+++ b/model/pytorch/dffml_model_pytorch/pytorch_base.py
@@ -63,6 +63,14 @@ class PyTorchModelConfig:
                 map(self.clstype, self.classifications)
             )
 
+class LossFunctionNotFoundError(Exception):
+    """
+    Exception raised when loss function is misspelled.
+    """
+    def __init__(self, message="Loss function is not valid!"):
+        self.message = message
+        super().__init__(self.message)
+
 
 class PyTorchModelContext(ModelContext):
     def __init__(self, parent):
@@ -89,6 +97,9 @@ class PyTorchModelContext(ModelContext):
             self._model = self.createModel()
 
         self.set_model_parameters()
+
+        if self.parent.config.loss is None:
+            raise LossFunctionNotFoundError()
 
         self.criterion = self.parent.config.loss.function
         self.optimizer = getattr(optim, self.parent.config.optimizer)(


### PR DESCRIPTION
Solved issue #910.

**Exception message:**
Before change - 'Nonetype' object has no attribute 'function'
After change- Loss function is not valid!