### PR TITLE
model: pytorch: Custom exception when loss function is misspelled

### DIFF
--- a/model/pytorch/dffml_model_pytorch/pytorch_base.py
+++ b/model/pytorch/dffml_model_pytorch/pytorch_base.py
@@ -63,6 +63,13 @@ class PyTorchModelConfig:
                 map(self.clstype, self.classifications)
             )
 
+class LossFunctionNotFoundError(Exception):
+    '''
+        Exception raised when loss function is misspelled.
+    '''
+    def __init__(self, message="Loss function is not valid!"):
+        self.message = message
+        super().__init__(self.message)
 
 class PyTorchModelContext(ModelContext):
     def __init__(self, parent):
@@ -89,6 +96,9 @@ class PyTorchModelContext(ModelContext):
             self._model = self.createModel()
 
         self.set_model_parameters()
+
+        if self.parent.config.loss is None:
+            raise LossFunctionNotFoundError()
 
         self.criterion = self.parent.config.loss.function
         self.optimizer = getattr(optim, self.parent.config.optimizer)(

--- a/model/pytorch/dffml_model_pytorch/pytorch_base.py
+++ b/model/pytorch/dffml_model_pytorch/pytorch_base.py
@@ -63,14 +63,6 @@ class PyTorchModelConfig:
                 map(self.clstype, self.classifications)
             )
 
-class LossFunctionNotFoundError(Exception):
-    '''
-        Exception raised when loss function is misspelled.
-    '''
-    def __init__(self, message="Loss function is not valid!"):
-        self.message = message
-        super().__init__(self.message)
-
 class PyTorchModelContext(ModelContext):
     def __init__(self, parent):
         super().__init__(parent)
@@ -96,9 +88,6 @@ class PyTorchModelContext(ModelContext):
             self._model = self.createModel()
 
         self.set_model_parameters()
-
-        if self.parent.config.loss is None:
-            raise LossFunctionNotFoundError()
 
         self.criterion = self.parent.config.loss.function
         self.optimizer = getattr(optim, self.parent.config.optimizer)(

--- a/model/pytorch/dffml_model_pytorch/pytorch_base.py
+++ b/model/pytorch/dffml_model_pytorch/pytorch_base.py
@@ -63,6 +63,7 @@ class PyTorchModelConfig:
                 map(self.clstype, self.classifications)
             )
 
+
 class PyTorchModelContext(ModelContext):
     def __init__(self, parent):
         super().__init__(parent)

--- a/model/pytorch/dffml_model_pytorch/utils/utils.py
+++ b/model/pytorch/dffml_model_pytorch/utils/utils.py
@@ -76,6 +76,12 @@ class NumpyToTensor(Dataset):
         return len(self.data)
 
 
+class LossFunctionNotFoundError(Exception):
+    '''
+    Exception raised when Loss function is misspelled.
+    '''
+    pass
+
 @base_entry_point("dffml.model.pytorch.loss", "loss")
 class PyTorchLoss(BaseDataFlowFacilitatorObject):
     def __init__(self, config):
@@ -84,10 +90,17 @@ class PyTorchLoss(BaseDataFlowFacilitatorObject):
 
     @classmethod
     def load(cls, class_name: str = None):
+        loss_function = None
+
         for name, loss_class in inspect.getmembers(nn, inspect.isclass):
             if name.endswith("Loss"):
                 if name.lower() == class_name:
-                    return getattr(sys.modules[__name__], name + "Function")
+                    loss_function = getattr(sys.modules[__name__], name + "Function")
+
+        if loss_function is None:
+            raise LossFunctionNotFoundError(f"Loss function is not valid! Function name given was {class_name}")
+
+        return loss_function
 
 
 for name, loss_class in inspect.getmembers(nn, inspect.isclass):

--- a/model/pytorch/dffml_model_pytorch/utils/utils.py
+++ b/model/pytorch/dffml_model_pytorch/utils/utils.py
@@ -77,10 +77,10 @@ class NumpyToTensor(Dataset):
 
 
 class LossFunctionNotFoundError(Exception):
-    '''
+    """
     Exception raised when Loss function is misspelled.
-    '''
-    pass
+    """
+
 
 @base_entry_point("dffml.model.pytorch.loss", "loss")
 class PyTorchLoss(BaseDataFlowFacilitatorObject):
@@ -95,10 +95,14 @@ class PyTorchLoss(BaseDataFlowFacilitatorObject):
         for name, loss_class in inspect.getmembers(nn, inspect.isclass):
             if name.endswith("Loss"):
                 if name.lower() == class_name:
-                    loss_function = getattr(sys.modules[__name__], name + "Function")
+                    loss_function = getattr(
+                        sys.modules[__name__], name + "Function"
+                    )
 
         if loss_function is None:
-            raise LossFunctionNotFoundError(f"Loss function is not valid! Function name given was {class_name}")
+            raise LossFunctionNotFoundError(
+                f"Loss function is not valid! Function name given was {class_name}"
+            )
 
         return loss_function
 


### PR DESCRIPTION
solved issue #910.

Exception message
before change - "AttributeError : 'NoneType' object has no attribute 'function' ".
after change - "LossFunctionNotFoundError : Loss function is not valid ".