### PR TITLE
Check for alternate package name (-, _) having .egg-link

### DIFF
--- a/dffml/util/packaging.py
+++ b/dffml/util/packaging.py
@@ -11,13 +11,17 @@ def is_develop(package_name: str) -> Union[bool, pathlib.Path]:
     """
     Returns True if the package is installed in development mode.
     """
+    alt_package_name = package_name.replace("-", "_")
     for syspath in map(pathlib.Path, sys.path):
         # Check if egg-link is present
         egg_link = syspath / f"{package_name}.egg-link"
+        alt_egg_link = syspath / f"{alt_package_name}.egg-link"
         if egg_link.is_file():
             return pathlib.Path(egg_link.read_text().split("\n")[0])
+        elif alt_egg_link.is_file():
+            return pathlib.Path(alt_egg_link.read_text().split("\n")[0])
         # Check if path entry is parent of module directory itself
-        module_dir = syspath / f"{package_name.replace('-', '_')}"
+        module_dir = syspath / f"{alt_package_name}"
         if module_dir.is_dir():
             return syspath
     return False


### PR DESCRIPTION
This PR addresses #648:
Adds a check if a package name has `_` instead of `-` with a `.egg-link`.