### PR TITLE
Cast predict to input dtype

### DIFF
--- a/model/scikit/dffml_model_scikit/scikit_base.py
+++ b/model/scikit/dffml_model_scikit/scikit_base.py
@@ -148,7 +148,10 @@ class ScikitContext(ModelContext):
             )
             target = self.parent.config.predict.name
             record.predicted(
-                target, self.clf.predict(predict)[0], self.confidence
+                target, 
+                self.parent.config.predict.dtype(self.clf.predict(predict)[0]) if \
+                    self.parent.config.predict.dtype is not str else \
+                    self.clf.predict(predict)[0], self.confidence
             )
             yield record
 
@@ -260,7 +263,10 @@ class ScikitContextUnsprvised(ScikitContext):
                 "Predicted cluster for {}: {}".format(predict, prediction)
             )
             target = self.parent.config.predict.name
-            record.predicted(target, prediction[0], self.confidence)
+            record.predicted(target,
+                self.parent.config.predict.dtype(prediction[0]) if \
+                    self.parent.config.predict.dtype is not str else \
+                    prediction[0], self.confidence)
             yield record
 
 

--- a/model/scikit/dffml_model_scikit/scikit_base.py
+++ b/model/scikit/dffml_model_scikit/scikit_base.py
@@ -148,10 +148,11 @@ class ScikitContext(ModelContext):
             )
             target = self.parent.config.predict.name
             record.predicted(
-                target, 
-                self.parent.config.predict.dtype(self.clf.predict(predict)[0]) if \
-                    self.parent.config.predict.dtype is not str else \
-                    self.clf.predict(predict)[0], self.confidence
+                target,
+                self.parent.config.predict.dtype(self.clf.predict(predict)[0])
+                if self.parent.config.predict.dtype is not str
+                else self.clf.predict(predict)[0],
+                self.confidence,
             )
             yield record
 
@@ -263,10 +264,13 @@ class ScikitContextUnsprvised(ScikitContext):
                 "Predicted cluster for {}: {}".format(predict, prediction)
             )
             target = self.parent.config.predict.name
-            record.predicted(target,
-                self.parent.config.predict.dtype(prediction[0]) if \
-                    self.parent.config.predict.dtype is not str else \
-                    prediction[0], self.confidence)
+            record.predicted(
+                target,
+                self.parent.config.predict.dtype(prediction[0])
+                if self.parent.config.predict.dtype is not str
+                else prediction[0],
+                self.confidence,
+            )
             yield record
 
 


### PR DESCRIPTION
Fixes #651

Predicted values are type casted to input type if input isn't `str`.