### PR TITLE
Fix typo in GSOC 2021 guide

### DIFF
--- a/docs/contributing/gsoc/2021.md
+++ b/docs/contributing/gsoc/2021.md
@@ -71,7 +71,7 @@ project before the end of the summer, and have more that you want to do.
 
 - Make your first contribution!
 
-  - Don't be afraid to not get it write on the first try. If we all got
+  - Don't be afraid to not get it right on the first try. If we all got
     everything right on the first try there would be no bugs in software. And
     there are LOTS of bugs in software.
 


### PR DESCRIPTION
There was a typo that I just saw while reading the DFFML's GSOC 2021 guide, which was been corrected now.