### PR TITLE
docs: fix a typo (for GSoC assessment purpose, do not merge)

### DIFF
--- a/docs/contributing/maintainers.rst
+++ b/docs/contributing/maintainers.rst
@@ -25,7 +25,7 @@ script.
 .. image:: /images/pypi-token-to-github-secret.gif
 
 Finally, update the ``PYPI_TOKENS`` file in ``.github/workflows/testing.yml``.
-Add a line for the plugin along with it's sceret.
+Add a line for the plugin along with its sceret.
 
 Doing a Release
 ---------------


### PR DESCRIPTION
I am very sorry that I learned about the GSoC 2021 program only two days before the proposal submission deadline. The PR below only fixed a typo in the document to prove that I am capable of interacting with the community, please do not merge it as it's only for interactive assessment.

for GSoC assessment purpose, do not merge
