### PR TITLE
docs: arch: Mutable config properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cached_download/unpack_archive()` are now functions
 - Model `directory` property to `location`
 - `high_level` split into `ml`, `dataflow` & `source` submodules
+- Config objects now support mutability/immutability at the property scope.
+  See `docs/arch/0003-Config-Property-Mutable-vs-Immutable` for details.
 ### Fixed
 - Record object key properties are now always strings
 

--- a/dffml/df/memory.py
+++ b/dffml/df/memory.py
@@ -1549,7 +1549,8 @@ class MemoryOrchestratorContext(BaseOrchestratorContext):
         if self.config.max_ctxs is not None and self.config.max_ctxs > len(
             ctxs
         ):
-            self.config.max_ctxs = None
+            with self.config.no_enforce_immutable():
+                self.config.max_ctxs = None
         # Create tasks to wait on the results of each of the contexts submitted
         for ctxs_index in range(0, len(ctxs)):
             if (

--- a/dffml/model/model.py
+++ b/dffml/model/model.py
@@ -78,7 +78,10 @@ class Model(BaseDataFlowFacilitatorObject):
         if isinstance(location, pathlib.Path):
             # to treat "~" as the the home location rather than a literal
             location = location.expanduser().resolve()
-            self.config.location = location
+            # TODO Change all model configs to make them support mutable
+            # location config properties
+            with self.config.no_enforce_immutable():
+                self.config.location = location
 
     def __call__(self) -> ModelContext:
         self._make_config_location()

--- a/dffml/service/dev.py
+++ b/dffml/service/dev.py
@@ -964,6 +964,9 @@ class MakeDocsConfig:
         "If set a SimpleHTTP server would be started to show generated docs",
         default=False,
     )
+    no_strict: bool = field(
+        "If set do not fail on Sphinx warnings", default=False,
+    )
 
 
 class MakeDocs(CMD):
@@ -1028,12 +1031,14 @@ class MakeDocs(CMD):
                 for e in pkg_resources.iter_entry_points("console_scripts")
                 if e.name.startswith("sphinx-build")
             ][0],
-            "-W",
             "-b",
             "html",
             "docs",
             str(pages_path),
         ]
+        # Fail on warnings unless -no-strict is given
+        if not self.no_strict:
+            cmd.insert(1, "-W")
         returncode = await self._exec_cmd(cmd)
         if returncode != 0:
             raise SphinxBuildError

--- a/dffml/source/df.py
+++ b/dffml/source/df.py
@@ -164,7 +164,10 @@ class DataFlowSourceContext(BaseSourceContext):
             async with config_cls.withconfig({}) as configloader:
                 async with configloader() as loader:
                     exported = await loader.loadb(dataflow_path.read_bytes())
-                self.parent.config.dataflow = DataFlow._fromdict(**exported)
+                with self.parent.config.no_enforce_immutable():
+                    self.parent.config.dataflow = DataFlow._fromdict(
+                        **exported
+                    )
 
         self.octx = await self.parent.orchestrator(
             self.parent.config.dataflow

--- a/dffml/source/dir.py
+++ b/dffml/source/dir.py
@@ -43,7 +43,8 @@ class DirectorySource(MemorySource):
     def __init__(self, config):
         super().__init__(config)
         if isinstance(getattr(self.config, "foldername", None), str):
-            self.config.foldername = pathlib.Path(self.config.foldername)
+            with self.config.no_enforce_immutable():
+                self.config.foldername = pathlib.Path(self.config.foldername)
 
     async def __aenter__(self) -> "BaseSourceContext":
         await self._open()
@@ -64,9 +65,10 @@ class DirectorySource(MemorySource):
         ):
             if os.path.isfile(self.config.labels[0]):
                 # Update labels with list read from the file
-                self.config.labels = pathlib.Path.read_text(
-                    pathlib.Path(self.config.labels[0])
-                ).split(",")
+                with self.config.no_enforce_immutable():
+                    self.config.labels = pathlib.Path.read_text(
+                        pathlib.Path(self.config.labels[0])
+                    ).split(",")
 
         elif self.config.labels != ["unlabelled"]:
             label_folders = [

--- a/dffml/source/file.py
+++ b/dffml/source/file.py
@@ -40,7 +40,8 @@ class FileSource(BaseSource):
         super().__init__(config)
 
         if isinstance(getattr(self.config, "filename", None), str):
-            self.config.filename = pathlib.Path(self.config.filename)
+            with self.config.no_enforce_immutable():
+                self.config.filename = pathlib.Path(self.config.filename)
 
     async def __aenter__(self) -> "BaseSourceContext":
         await self._open()

--- a/dffml/util/python.py
+++ b/dffml/util/python.py
@@ -3,6 +3,7 @@ Python specific helper functions
 """
 import types
 import pathlib
+import inspect
 import importlib
 from typing import Optional, Callable, Union, Tuple, Iterator
 
@@ -80,3 +81,97 @@ def modules(
             continue
         # Import module
         yield import_name, importlib.import_module(import_name)
+
+
+# See comment at beginning of within_method()
+IN_IPYTHON = False
+CHECKED_IN_IPYTHON = False
+IPYTHON_INSPECT_PATCHED = False
+
+
+def within_method(obj: object, method_name: str, max_depth: int = -1) -> bool:
+    """
+    Return True if a caller is being called from a given method of a given
+    object.
+
+    Parameters
+    ----------
+    obj : object
+        Check if we are within a method of this object.
+    method_name : str
+        Check if we are within a method by this name.
+    max_depth : int, optional (-1)
+        Stop checking stack frames after we have checked this many.
+
+    Returns
+    -------
+    within : boolean
+        True if the calling function is being called from within the method
+        given bound to the object given.
+
+    Examples
+    --------
+
+    >>> from dffml import within_method
+    >>>
+    >>> class FirstClass:
+    ...     def feedface(self):
+    ...         print(within_method(self, "__init__", max_depth=3))
+    ...
+    >>> first = FirstClass()
+    >>> first .feedface()
+    False
+    >>>
+    >>> class SecondClass(FirstClass):
+    ...     def __init__(self):
+    ...         self.feedface()
+    ...
+    >>> second = SecondClass()
+    True
+    >>>
+    >>> class ThirdClass(SecondClass):
+    ...     def __init__(self):
+    ...         self.deadbeef()
+    ...
+    ...     def deadbeef(self):
+    ...         self.feedface()
+    ...
+    >>> third = ThirdClass()
+    False
+    """
+    # HACK Fix for if we are running in IPython notebook. Sometimes it doesn't
+    # patch inspect.findsource as is intended
+    # References:
+    # - https://github.com/ipython/ipython/issues/1456
+    # - https://github.com/ipython/ipython/commit/298fdab5025745cd25f7f48147d8bc4c65be9d4a#diff-3a77d00d5690f670e9ac680f06b8ffe7ca902c6d325673f32e719d8e55b11ae3R209
+    global IN_IPYTHON
+    global CHECKED_IN_IPYTHON
+    global IPYTHON_INSPECT_PATCHED
+    if not CHECKED_IN_IPYTHON:
+        try:
+            get_ipython()
+            IN_IPYTHON = True
+        except:
+            pass
+        CHECKED_IN_IPYTHON = True
+        if IN_IPYTHON and not IPYTHON_INSPECT_PATCHED:
+            import IPython.core.ultratb
+
+            inspect.findsource = IPython.core.ultratb.findsource
+            IPYTHON_INSPECT_PATCHED = False
+    # Grab stack frames
+    try:
+        frames = inspect.stack()
+    except ImportError:
+        # HACK ImportError Fix for lazy_import rasing on autosklearn/smac: emcee
+        return True
+    for i, frame_info in enumerate(frames):
+        if max_depth != -1 and i >= max_depth:
+            break
+        if (
+            frame_info.function == method_name
+            and "self" in frame_info.frame.f_locals
+            and frame_info.frame.f_locals["self"] is obj
+        ):
+            return True
+    return False

--- a/docs/arch/0003-Config-Property-Mutable-vs-Immutable.rst
+++ b/docs/arch/0003-Config-Property-Mutable-vs-Immutable.rst
@@ -1,0 +1,102 @@
+3. Config Property Mutable vs Immutable
+=======================================
+
+Date: 2021-08-04
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+This document and 0004-Model-Saving-and-Loading were drafted at the same
+time. See the 2021-05-25 Weekly Sync Meeting recording for more details.
+
+Through discussion about model config properties in relation to modification of
+hyperparameters we found that there are two kinds of config properties in
+general (as it relates to this document).
+
+- Immutable
+
+    - Properties whose values are fundamentally tied to the object the config is
+      used for. For the lifetime of the object.
+
+    - If these config properties change, a new instance of the object using the
+      config should be instantiated.
+
+    - Think of these like the concious or the soul of the object. You cannot
+      modify them, because then that would be a new object.
+
+- Mutable
+
+    - Properties whose values may could change over the lifetime of the
+      object, yet the object is still fundamentally the same thing.
+
+    - Think of these like the organs of the object. You could transplant an
+      organ from one person into another, but you didn't change who that person
+      is.
+
+Decision
+--------
+
+Similar to the way :py:class:`typing.NamedTuple` works, config properties will
+default to immutable. This way implementers of classes can assume they don't
+need to deal with state changes to config properties unless they've explicitly
+opted in.
+
+We will require that a callback function be registered with the config class.
+This way we ensure that modification of mutable values is handled somewhere.
+To combat class authors from declaring properties as mutable, without
+registering the callback. We'll raise an exception if the callback hasn't been
+registered and any property is set or retrieved, or the instance is exported.
+
+In the following example we have a hyperparameter, C. Out model wants to support
+changes to it at runtime, so we mark it as mutable.
+
+.. code-block:: python
+
+    @config
+    class MyModelConfig:
+        C: int = field("C hyperparameter", mutable=True)
+
+Since we've marked C as mutable, we must add a callback which deals with
+mutations to the config object.
+
+The callback we add accepts the key being modified within the config structure
+and the value it was set to. For demonstration purposes we will use the value of
+C in the model object. The callback's use of :py:func:`setattr` when the value
+of C is updated in the config structure results in the value of C in the model
+object also changing.
+
+.. code-block:: python
+
+    class MyModel(Model):
+        CONFIG = MyModelConfig
+        CONTEXT = ModelConfig
+
+        def __init__(self, config):
+            # Callback which will change self.C when self.config.C is changed
+            self.config.add_mutable_callback(lambda key, value: setattr(self, key, value))
+            # Use the value of C
+            self.C = self.config.C
+
+    model = MyModel(C=0)
+    assert model.C == 0
+    model.config.C = 42
+    assert model.C == 42
+
+If a user wants to modify an immutable property, they must create a new instance
+of the object/config.
+
+Consequences
+------------
+
+The :py:func:`field <dffml.base.field>` function will need to be modified to add
+a ``mutable`` keyword argument.
+
+We need to figure out how we'll support modifying sub-objects of configs. This
+is something we'll consider for the future. For example PyTorch has optimizers
+and loss functions which are objects which reside in the config of the main
+PyTorchModelConfig.

--- a/docs/arch/index.rst
+++ b/docs/arch/index.rst
@@ -8,3 +8,4 @@ https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
     :titlesonly:
 
     0002-Object-Loading-and-Instantiation-in-Examples
+    0003-Config-Property-Mutable-vs-Immutable

--- a/model/vowpalWabbit/dffml_model_vowpalWabbit/vw_base.py
+++ b/model/vowpalWabbit/dffml_model_vowpalWabbit/vw_base.py
@@ -212,7 +212,8 @@ class VWContext(ModelContext):
         return
 
     async def __aenter__(self):
-        self.parent.config.vwcmd = self.modify_config()
+        with self.parent.config.no_enforce_immutable():
+            self.parent.config.vwcmd = self.modify_config()
         self.clf = self._load_model()
         return self
 


### PR DESCRIPTION
- We started with NamedTuples, those had immutable properties
- Then we moved to dataclasses, we currently have properties and mutable
- Now we want to move to a dataclass or dataclass like approach where we default to having properties be immutable. We add a mutable keyword argument to field() which would signify that the config property is allowed to be modified without creating an entirely new instance of the config object.
  - Motivation here is that for model hyperparameter tuning we need to support in a standard way how properties of models can be tuned at runtime without instantiating an entirely new model class.
  - Another motivation which is father off is automl. When we go to do automl, whatever is “the” automl engine we implement will need to know which properties of model configs it can tweak in an automated fashion, and which things, for example the network architecture for neural networks, or even so basic as the directory property are not allowed be tweaked automatically.
- Implementation
  - Assume all properties are immutable unless explicitly marked as mutable
  - The class which uses the config must register a callback function to handle changes to config properties
https://github.com/intel/dffml/pull/1122/files#diff-aff838ca657169c089cf5d6e41383c0eaeba07312d4ca5355ac0bdf91d08fa00R80
  - Please comment on the PR if you have any questions comments concerns
    - There is for sure more stuff to iron out here
      - For example, what happens if the package version changes?
- This discussion stemmed from lack of clarity on model saving and loading. Hashim was unsure when implementing a tutorial what should happen if a model is instantiated in Python with certain hyperparameters but the model exists in a saved state on disk.
  - What currently happens (at least in the case of scikit) is that the saved state is load and the config properties are ignored essentially, because they are not used to instantiate the scikit model class.
  - There is another ADR within the referenced PR that talks about model saving and loading. We essentially decided that in memory properties should override saved properties provided that those properties are mutable. And this is where the mutable discucussion came from.
- We decided that these changes will need to take place as a part of Saahil’s project.
  - Hashim did some work on this https://github.com/intel/dffml/pull/1122#issuecomment-859773956
  - @sakshamarora1 can help coordinate on this across @mHash1m and @programmer290399
