### PR TITLE
docs: conf: Fix .ipynb download button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,15 +84,15 @@ source_suffix = {
 }
 
 # Download button for ipython notebooks
-nb_version = ""
-if "." not in version:
-    nb_version = "master/"
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = r"""
 {% set docname = env.doc2path(env.docname, base=None) %}
+{% if "." not in env.config.release %}
+    {% set nb_version = "master/" %}
+{% endif %}
 
 .. image:: ../../images/Download-.ipynb-button.svg
-    :target: https://intel.github.io/dffml/{{nbversion}}{{docname[:-6]}}ipynb
+    :target: https://intel.github.io/dffml/{{ nb_version }}{{ docname[:-6] }}ipynb
     :alt: Notebook download button
 
 |


### PR DESCRIPTION
@pdxjohnny unfortunately the download .ipynb button failed on master docs.  Perhaps I didn't test it well enough.
I've managed to fix it.

Tested it with master and it directs to : https://intel.github.io/dffml/master/examples/notebooks/moving_between_models.ipynb
Tested it by making the if condition false and it directs to: https://intel.github.io/dffml/examples/notebooks/moving_between_models.ipynb

So it seems to be behaving right, now.

Thought about testing it on tag release too but there are too many changes to docs since then and the previous script wasn't running so not sure.
Let me know if I should figure that out.