### PR TITLE
model: pytorch: pretrained: Add support for additional layers Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Operations for file (de)compression
 - Usecase example notebook for "Evaluating Model Performance"
 - Tests for all notebooks auto created and run via ``test_notebooks.py``
+- Support for additional layers in pytorch pretrained models via Python API
 ### Changed
 - Calls to hashlib now go through helper functions
 - Build docs using `dffml service dev docs`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ jsbeautifier>=1.14.0
 twine
 # Test requirements
 httptest>=0.0.15
-Pillow>=7.1.2
+Pillow>=8.3.1
 pre-commit
 ipykernel
 matplotlib


### PR DESCRIPTION
fixes: #1147 

* This PR is a dependency for the usecase example notebook I'm currently working on, ie. "Transferlearning".

* I ended up setting `layers: Any`in the `PyTorchPreTrainedModelConfig` and also skipping `convert_value()` in `base.py` if field type is `Any` since it tries to create an instance of the type. 

* Seems to be working as I handle the formatting of the parameter in `pytorch_pretrained` itself, but what could be the implications of this? 

* It appears we don't have `Any` type fields, even if we add in future and want to by-pass the checks in `base.py`, we can simply provide multiple arguments to `isinstance()` to check against along with `dict`, to allow the `convert_value()` process.

* Alternatively, I could also create a `.yaml` inside the notebook (for the time being)  if this approach doesn't seem right.

* Using `Pillow==8.2.0` to temporarily fix the pytorch errors. Seems like there's a pending fix python-pillow/Pillow#5572 so should be okay soon