### PR TITLE
ci: run: Fix for infinite run of commit msg lint on master

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -189,7 +189,7 @@ function run_style() {
 }
 
 function run_commit(){
-  BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  BRANCH="$(echo $GITHUB_REF | cut -d'/' -f 3)"
   echo "On Branch: ${BRANCH}"
   if [[ "$BRANCH" != "master" ]]; then
     dffml service dev lint commits

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -189,7 +189,11 @@ function run_style() {
 }
 
 function run_commit(){
-  dffml service dev lint commits
+  BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  echo "On Branch: ${BRANCH}"
+  if [[ "$BRANCH" != "master" ]]; then
+    dffml service dev lint commits
+  fi
 }
 
 function run_docs() {


### PR DESCRIPTION
* I am not sure what the branch name is for master inside the GitHub actions env 
* It  may or may not be `master` ,  I cannot verify it directly as I cannot push to master and check, 
* If it is different than `master` then one small change would be required [here](https://github.com/intel/dffml/pull/1177/files#diff-7b436cb5923ba7f66ccf2e140b342330400dcb1d6776d03444564dc34c5379f1R194) , just replace master with appropriate branch name in the env