### PR TITLE
model: scikit: tests: Fixed failing scikit tests 

### DIFF
--- a/model/scikit/tests/test_scikit.py
+++ b/model/scikit/tests/test_scikit.py
@@ -183,6 +183,7 @@ class TestScikitModel:
                     else:
                         prediction = record.prediction(target).value
                     if self.MODEL_TYPE == "CLASSIFICATION":
+                        print("prediction:", prediction)
                         self.assertIn(prediction, [2, 4])
                     elif self.MODEL_TYPE == "REGRESSION":
                         correct = FEATURE_DATA_REGRESSION[int(record.key)][3]

--- a/model/scikit/tests/test_scikit.py
+++ b/model/scikit/tests/test_scikit.py
@@ -183,7 +183,6 @@ class TestScikitModel:
                     else:
                         prediction = record.prediction(target).value
                     if self.MODEL_TYPE == "CLASSIFICATION":
-                        print("prediction:", prediction)
                         self.assertIn(prediction, [2, 4])
                     elif self.MODEL_TYPE == "REGRESSION":
                         correct = FEATURE_DATA_REGRESSION[int(record.key)][3]

--- a/model/scikit/tests/test_scikit.py
+++ b/model/scikit/tests/test_scikit.py
@@ -58,7 +58,7 @@ class TestScikitModel:
                 for i in range(0, len(A))
             ]
 
-        elif cls.MODEL_TYPE in regeressor_types:
+        elif cls.MODEL_TYPE in regressor_types:
             cls.features.append(Feature("A", float, 1))
             cls.features.append(Feature("B", float, 1))
             cls.features.append(Feature("C", float, 1))
@@ -149,7 +149,7 @@ class TestScikitModel:
                     self.model.config.predict,
                     self.sources,
                 )
-        elif self.MODEL_TYPE in regeressor_types:
+        elif self.MODEL_TYPE in regressor_types:
             res = await score(
                 self.model,
                 self.scorer,
@@ -319,7 +319,7 @@ CLUSTERERS = [
 supervised_estimators = ["classifier", "regressor"]
 unsupervised_estimators = ["clusterer"]
 classifier_types = ["CLASSIFICATION", "MULTI_CLASSIFICATION"]
-regeressor_types = ["REGRESSION", "MULTI_REGRESSION"]
+regressor_types = ["REGRESSION", "MULTI_REGRESSION"]
 valid_estimators = supervised_estimators + unsupervised_estimators
 
 for clf in CLASSIFIERS:
@@ -341,7 +341,7 @@ for clf in CLASSIFIERS:
         setattr(sys.modules[__name__], test_cls.__qualname__, test_cls)
 
 for reg in REGRESSORS:
-    for model_type in regeressor_types:
+    for model_type in regressor_types:
         test_cls = type(
             f"Test{reg}Model",
             (TestScikitModel, AsyncTestCase),

--- a/model/scikit/tests/test_scikit_integration.py
+++ b/model/scikit/tests/test_scikit_integration.py
@@ -207,7 +207,7 @@ class TestScikitRegression(AsyncTestCase):
         )
         self.assertTrue(isinstance(results, list))
         self.assertTrue(results)
-        results = results[0]
+        results = results[0].export()
         self.assertIn("prediction", results)
         results = results["prediction"]
         self.assertIn("true_label", results)
@@ -357,7 +357,7 @@ class TestScikitClustering(AsyncTestCase):
             self.stdout.seek(0)
             self.assertTrue(isinstance(results, list))
             self.assertTrue(results)
-            results = results[0]
+            results = results[0].export()
             self.assertIn("prediction", results)
             results = results["prediction"]
             self.assertIn("cluster", results)

--- a/model/scikit/tests/test_scikit_scorers.py
+++ b/model/scikit/tests/test_scikit_scorers.py
@@ -23,6 +23,10 @@ class TestScikitScorer(TestScikitModel):
         )
         self.assertTrue(float("-inf") < res < float("inf"))
 
+    async def test_02_predict(self):
+        # Scorers need not to have tests related to predict
+        pass
+
 
 REGRESSION_SCORERS = [
     "ExplainedVarianceScore",

--- a/model/scikit/tests/test_scikit_scorers.py
+++ b/model/scikit/tests/test_scikit_scorers.py
@@ -11,7 +11,7 @@ from .test_scikit import (
     CLUSTERERS,
     CLASSIFIERS,
     TestScikitModel,
-    regeressor_types,
+    regressor_types,
     classifier_types,
 )
 
@@ -68,7 +68,7 @@ CLUSTERING_SCORERS = [
 
 for scorer in REGRESSION_SCORERS:
     for reg in REGRESSORS:
-        for model_type in regeressor_types:
+        for model_type in regressor_types:
             if scorer in MULTIOUTPUT_EXCEPTIONS and "MULTI_" in model_type:
                 continue
             test_cls = type(


### PR DESCRIPTION
* Related: #1264 
* PR is Ready for Review, Ping:@pdxjohnny   
* This bug was introduced in PR #1226, where I removed a seemingly redundant code block [here](https://github.com/intel/dffml/pull/1226/commits/ff096ae4ddec127815b6459e4ed5eedc92291f91#diff-be04a13bbc3837205b593fd019f43a1573590f980b28210e5d914879901eecc5L26-L28), after discussing with @sk-ip on gitter as shown below:
![scikit_test_bug_origin](https://user-images.githubusercontent.com/41383069/150666625-08ecad3b-443e-4bef-bdf3-052722b9374b.png)
* Well he might not have realized that it wasn't there by mistake, it was supposed to override the baseclass implementation of `test_02_predict` as it was irrelevant for this test.
* I have fixed the test and also have added a comment describing why it has been left blank.
