### PR TITLE
Add Notification on OS in Quickstart

### DIFF
--- a/docs/quickstart/model.rst
+++ b/docs/quickstart/model.rst
@@ -1,6 +1,8 @@
 Quickstart
 ==========
 
+ **The commands line provided in this page are for Linux**
+
 In this example we have employee data telling us the employee's years of
 experience, our level of trust in them, their level of expertise, and their
 salary. Our goal will be to predict what the salary of a new hire should be,


### PR DESCRIPTION
On the INSTALLATION page, we addressed that the officially supported OS is Linux. I think it would also be beneficial for the new users if we add this notification in every implementation section (like Quickstart) so they can be aware.