### PR TITLE
Fixed broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Please see the [contributing docs page](https://intel.github.io/dffml/main/contributing/).
+Please see the [contributing docs page](https://intel.github.io/dffml/contributing/).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://intel.github.io/dffml/main/index.html
 
 ## Contributing
 
-The [contributing page](https://intel.github.io/dffml/main/contributing/index.html)
+The [contributing page](https://intel.github.io/dffml/contributing/index.html)
 will guide you through getting setup and contributing to DFFML.
 
 ## Help


### PR DESCRIPTION
This resolves issue #1336  wherein links referencing to the documentation and contributing guidelines were broken.