### PR TITLE
ci: testing: build: Use artifact attestations

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,6 +14,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +62,19 @@ jobs:
         python-version: ${{ matrix.python-version }}
         module-name: dffml
         output-directory: sbom
+    - name: Get built filenames
+      id: filename
+      run: |
+        echo "tar=$(cd dist/ && echo *.tar.gz)" >> $GITHUB_OUTPUT
+        echo "whl=$(cd dist/ && echo *.tar.gz)" >> $GITHUB_OUTPUT
+    - name: Attest Build Provenance
+      uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+      with:
+        subject-path: "dist/${{ steps.filename.outputs.tar }}"
+    - name: Attest Build Provenance
+      uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+      with:
+        subject-path: "dist/${{ steps.filename.outputs.whl }}"
     - name: in-toto attestation for cyclonedx SBOM
       id: in-toto-cyclonedx
       env:


### PR DESCRIPTION
Related: https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/