### PR TITLE
scripts: ossf scorecard pindeps: docs: Do not print pyproject.toml to stdout

### DIFF
--- a/scripts/ossf_scorecard_pindeps.py
+++ b/scripts/ossf_scorecard_pindeps.py
@@ -176,7 +176,7 @@ def pin_packages(cmd):
         )
 
         # snoop.pp(editable_packages, packages, pyproject)
-        print(pyproject_toml_path.read_text())
+        # print(pyproject_toml_path.read_text())
 
         cmd = [
             sys.executable,


### PR DESCRIPTION
Signed-off-by: John Andersen <john.s.andersen@intel.com>
